### PR TITLE
Fix check if tabContent is undefined for showing a tab by default.

### DIFF
--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -30,7 +30,8 @@ function showFirstTabContent(){
   const tabContent = document.getElementsByClassName("tab-content");
  
   //Make the first tab shown.
-  showContentForTab(tabContent[0].id, "peachpuff");
+  if (tabContent[0] !== undefined)
+    showContentForTab(tabContent[0].id, "peachpuff");
 }
 
 window.onscroll = changeNavbarStickiness;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -29,7 +29,7 @@ function addListenersToButtons() {
 function showFirstTabContent(){
   const tabContent = document.getElementsByClassName("tab-content");
  
-  //Make the first tab shown.
+  // Make the first tab shown.
   if (tabContent[0] !== undefined) {
     showContentForTab(tabContent[0].id, "peachpuff");
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -30,8 +30,9 @@ function showFirstTabContent(){
   const tabContent = document.getElementsByClassName("tab-content");
  
   //Make the first tab shown.
-  if (tabContent[0] !== undefined)
+  if (tabContent[0] !== undefined) {
     showContentForTab(tabContent[0].id, "peachpuff");
+  }
 }
 
 window.onscroll = changeNavbarStickiness;


### PR DESCRIPTION
Currently, we try to show the content of the first tab even if a page does not have any HTML elements with class tab-content. This produces an error in the console that does not cause any problems with functionality. In this change, we change the showFirstTabContent() function such that only when there is an element with class tab-content, then the first tab will be attempted to be displayed.