### PR TITLE
[2/X] Add tests for optional attendees functionality

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -34,7 +34,7 @@ public final class MeetingRequest {
   private final Collection<String> attendees = new HashSet<>();
 
   // Some optional attendees for this new meeting. Use a set to avoid duplicates.
-  private final Collection<String> optional_attendees = new HashSet<>();
+  private final Collection<String> optionalAttendees = new HashSet<>();
 
   // The duration of the meeting in minutes.
   private final long duration;
@@ -42,6 +42,12 @@ public final class MeetingRequest {
   public MeetingRequest(Collection<String> attendees, long duration) {
     this.duration = duration;
     this.attendees.addAll(attendees);
+  }
+  
+  public MeetingRequest(Collection<String> attendees, Collection<String> optionalAttendees, long duration) {
+    this.duration = duration;
+    this.attendees.addAll(attendees);
+    this.optionalAttendees.addAll(optionalAttendees);
   }
 
   /**
@@ -55,7 +61,7 @@ public final class MeetingRequest {
    * Returns a read-only copy of the people who are optional to attend this meeting.
    */
   public Collection<String> getOptionalAttendees() {
-    return Collections.unmodifiableCollection(optional_attendees);
+    return Collections.unmodifiableCollection(optionalAttendees);
   }
 
   /**
@@ -63,7 +69,7 @@ public final class MeetingRequest {
    */
   public void addOptionalAttendee(String attendee) {
     if (!attendees.contains(attendee)) {
-      optional_attendees.add(attendee);
+      optionalAttendees.add(attendee);
     }
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -43,7 +43,7 @@ public final class MeetingRequest {
     this.duration = duration;
     this.attendees.addAll(attendees);
   }
-  
+
   public MeetingRequest(Collection<String> attendees, Collection<String> optionalAttendees, long duration) {
     this.duration = duration;
     this.attendees.addAll(attendees);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -44,12 +44,6 @@ public final class MeetingRequest {
     this.attendees.addAll(attendees);
   }
 
-  public MeetingRequest(Collection<String> attendees, Collection<String> optionalAttendees, long duration) {
-    this.duration = duration;
-    this.attendees.addAll(attendees);
-    this.optionalAttendees.addAll(optionalAttendees);
-  }
-
   /**
    * Returns a read-only copy of the people who are required to attend this meeting.
    */

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -39,6 +39,7 @@ public final class FindMeetingQueryTest {
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -273,9 +274,10 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
-  public void optionalAttendeeIsConsidered() {
-    // Have each person have different events. We should see two options because each person has
-    // split the restricted times.
+  public void optionalAttendeeIsIgnoredInResult() {
+    // Have each person have different events. The optional 
+    // attendee should be ignored because there is no time
+    // that accomadates the optional attendee.
     //
     // Events  : |^^^^^|--A--|^^C^^|--B--|^^^^^|
     // Day     : |-----------------------------|
@@ -285,12 +287,12 @@ public final class FindMeetingQueryTest {
         new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B))
+            Arrays.asList(PERSON_B)),
         new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -303,8 +305,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void optionalAttendeeIsConsidered() {
-    // Have each person have different events. We should see two options because each person has
-    // split the restricted times.
+    // Have each person have different events. We should see two options because 
+    // there are results that accomadate for the optional attendee.
     //
     // Events  : |     |--A--|^^C^^|--B--|     |
     // Day     : |-----------------------------|
@@ -314,12 +316,12 @@ public final class FindMeetingQueryTest {
         new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B))
+            Arrays.asList(PERSON_B)),
         new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -328,5 +330,85 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void optionalAttendeeJustEnoughRoom() {
+    // Have one person optional attendee, but make it so that there is 
+    // just enough room at one point in the day to have the meeting.
+    // Optional attendee should be ignored becaue if we include him
+    // then we cannot find a time that works. 
+    // 
+    // Events  : |--A--|-B-| |----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), Arrays.asList(PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesWithGaps() {
+    // Have 2 optional attendees each of which have different events. We should see three options
+    // which are the gaps.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesWithoutGaps() {
+    // Have two optional attendees, but make it so that there is not enough room at any point in the day to
+    // have the meeting.
+    //
+    // Events  : |--A-----||------B----|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -267,6 +268,63 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsConsidered() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  : |^^^^^|--A--|^^C^^|--B--|^^^^^|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B))
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeIsConsidered() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  : |     |--A--|^^C^^|--B--|     |
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B))
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -277,7 +277,7 @@ public final class FindMeetingQueryTest {
   public void optionalAttendeeIsIgnoredInResult() {
     // Have each person have different events. The optional 
     // attendee should be ignored because there is no time
-    // that accomadates the optional attendee.
+    // that accommodates the optional attendee.
     //
     // Events  : |^^^^^|--A--|^^C^^|--B--|^^^^^|
     // Day     : |-----------------------------|
@@ -306,7 +306,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void optionalAttendeeIsConsidered() {
     // Have each person have different events. We should see two options because 
-    // there are results that accomadate for the optional attendee.
+    // there are results that accommodate for the optional attendee.
     //
     // Events  : |     |--A--|^^C^^|--B--|     |
     // Day     : |-----------------------------|
@@ -335,7 +335,7 @@ public final class FindMeetingQueryTest {
   public void optionalAttendeeJustEnoughRoom() {
     // Have one person optional attendee, but make it so that there is 
     // just enough room at one point in the day to have the meeting.
-    // Optional attendee should be ignored becaue if we include him
+    // Optional attendee should be ignored because if we include it
     // then we cannot find a time that works. 
     // 
     // Events  : |--A--|-B-| |----A----|
@@ -361,7 +361,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void optionalAttendeesWithGaps() {
-    // Have 2 optional attendees each of which have different events. We should see three options
+    // Have 2 optional attendees each of whom have different events. We should see three options
     // which are the gaps.
     //
     // Events  :       |--A--|     |--B--|
@@ -388,8 +388,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void optionalAttendeesWithoutGaps() {
-    // Have two optional attendees, but make it so that there is not enough room at any point in the day to
-    // have the meeting.
+    // Have two optional attendees, but make it so that there is not enough room at any point in the 
+    // day to have the meeting.
     //
     // Events  : |--A-----||------B----|
     // Day     : |---------------------|

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -292,7 +292,8 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -321,7 +322,8 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -350,7 +352,8 @@ public final class FindMeetingQueryTest {
         new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
             Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), Arrays.asList(PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -375,7 +378,9 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -401,14 +406,14 @@ public final class FindMeetingQueryTest {
         new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(), Arrays.asList(PERSON_A, PERSON_B), DURATION_60_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();
 
     Assert.assertEquals(expected, actual);
   }
-
-
 }
 


### PR DESCRIPTION
- Add 5 tests for optional attendees:
    - Test that optional attendee is ignored or included when returning valid time ranges

Tests meet requirements as follows:
1. optionalAttendeeIsIgnoredInResult: Based on everyAttendeeIsConsidered, add an optional attendee C who has an all-day event. The same three time slots should be returned as when C was not invited.

2. optionalAttendeeIsConsidered: Also based on everyAttendeeIsConsidered, add an optional attendee C who has an event between 8:30 and 9:00. Now only the early and late parts of the day should be returned.

3. optionalAttendeeJustEnoughRoom: Based on justEnoughRoom, add an optional attendee B who has an event between 8:30 and 8:45. The optional attendee should be ignored since considering their schedule would result in a time slot smaller than the requested time.

4. optionalAttendeesWithGaps: No mandatory attendees, just two optional attendees with several gaps in their schedules. Those gaps should be identified and returned.

5. optionalAttendeesWithoutGaps: No mandatory attendees, just two optional attendees with no gaps in their schedules. query should return that no time is available.