### PR TITLE
Add algorithm for finding the potential time ranges for meeting request considering optional attendees.

### DIFF
--- a/walkthroughs/week-5-tdd/project/pom.xml
+++ b/walkthroughs/week-5-tdd/project/pom.xml
@@ -38,6 +38,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -86,7 +86,7 @@ public final class FindMeetingQuery {
         Set<String> intersection = new HashSet<String>(event.getAttendees());
         intersection.retainAll(requestAttendees);
 
-        // If the intersection size is greater than 0, add this event time to the potential
+        // If the intersection is not empty, add this event time to the potential
         // conflicts.
         if (!intersection.isEmpty()) {
             potentialConflicts.add(event.getWhen());

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     // Find potential conflicts between scheduled events and request using only
     // mandatory attendees.
-    Collection<String> mandatoryAttendees = request.getAttendees();
+    ImmutableSet<String> mandatoryAttendees = ImmutableSet.copyOf(request.getAttendees());
     List<TimeRange> mandatoryAttendeeConflicts = getPotentialConflicts(events, mandatoryAttendees);
 
     // Find potential conflicts between scheduled events and request using all attendees.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -38,8 +38,9 @@ public final class FindMeetingQuery {
 
     // If time ranges based on all conflicts is not empty or no mandatory attendees
     // return the time ranges based on all conflicts.
-    if (!timeRanges.isEmpty() || mandatoryAttendees.isEmpty())
+    if (!timeRanges.isEmpty() || mandatoryAttendees.isEmpty()) {
       return timeRanges;
+    }
     
     // Return the time ranges based on mandatory attendee conflicts.
     return queryUsingPotentialConflicts(events, request, mandatoryAttendeeConflicts);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,9 +27,9 @@ public final class FindMeetingQuery {
     // Find potential conflicts between scheduled events and request using only
     // mandatory attendees.
     Collection<String> mandatoryAttendees = request.getAttendees();
-
-    // Find potential conflicts between scheduled events for all attendees.
     List<TimeRange> mandatoryAttendeeConflicts = getPotentialConflicts(events, mandatoryAttendees);
+
+    // Find potential conflicts between scheduled events and request using all attendees.
     List<TimeRange> allConflicts = new ArrayList(mandatoryAttendeeConflicts);
     allConflicts.addAll(getPotentialConflicts(events, request.getOptionalAttendees()));
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -36,7 +36,7 @@ public final class FindMeetingQuery {
     // Find time ranges based on all conflicts.
     Collection<TimeRange> timeRanges = queryUsingPotentialConflicts(events, request, allConflicts);
 
-    // If the number time ranges is positive or the number of mandatory attendees is zero
+    // If the number of time ranges is positive or the number of mandatory attendees is zero
     // return the time ranges based on all conflicts.
     if (timeRanges.size() > 0 || mandatoryAttendees.size() == 0)
       return timeRanges;
@@ -46,7 +46,7 @@ public final class FindMeetingQuery {
   }
 
   // Return time ranges for the request using potential conflicts provided.
-  public Collection<TimeRange> queryUsingPotentialConflicts(Collection<Event> events, 
+  private static Collection<TimeRange> queryUsingPotentialConflicts(Collection<Event> events, 
         MeetingRequest request, List<TimeRange> potentialConflicts) {
     // Sort the potential conflicts in order of ascending start time.
     Collections.sort(potentialConflicts, TimeRange.ORDER_BY_START);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -36,9 +36,9 @@ public final class FindMeetingQuery {
     // Find time ranges based on all conflicts.
     Collection<TimeRange> timeRanges = queryUsingPotentialConflicts(events, request, allConflicts);
 
-    // If the number of time ranges is positive or the number of mandatory attendees is zero
+    // If time ranges based on all conflicts is not empty or no mandatory attendees
     // return the time ranges based on all conflicts.
-    if (timeRanges.size() > 0 || mandatoryAttendees.size() == 0)
+    if (!timeRanges.isEmpty() || mandatoryAttendees.isEmpty())
       return timeRanges;
     
     // Return the time ranges based on mandatory attendee conflicts.
@@ -85,7 +85,7 @@ public final class FindMeetingQuery {
         Set<String> intersection = new HashSet<String>(event.getAttendees());
         intersection.retainAll(requestAttendees);
 
-        // If the intersection is not empty, add this event time to the potential
+        // If the intersection size is greater than 0, add this event time to the potential
         // conflicts.
         if (!intersection.isEmpty()) {
             potentialConflicts.add(event.getWhen());

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -34,7 +34,7 @@ public final class MeetingRequest {
   private final Collection<String> attendees = new HashSet<>();
 
   // Some optional attendees for this new meeting. Use a set to avoid duplicates.
-  private final Collection<String> optionalAttendees = new HashSet<>();
+  private final Collection<String> optional_attendees = new HashSet<>();
 
   // The duration of the meeting in minutes.
   private final long duration;
@@ -55,7 +55,7 @@ public final class MeetingRequest {
    * Returns a read-only copy of the people who are optional to attend this meeting.
    */
   public Collection<String> getOptionalAttendees() {
-    return Collections.unmodifiableCollection(optionalAttendees);
+    return Collections.unmodifiableCollection(optional_attendees);
   }
 
   /**
@@ -63,7 +63,7 @@ public final class MeetingRequest {
    */
   public void addOptionalAttendee(String attendee) {
     if (!attendees.contains(attendee)) {
-      optionalAttendees.add(attendee);
+      optional_attendees.add(attendee);
     }
   }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -101,7 +101,7 @@ public final class FindMeetingQueryTest {
     // Have each person have different events. We should see two options because each person has
     // split the restricted times.
     //
-    // Events  :       |--A--|     |--B--|
+    // Events  :       |--A--|    |--B--|
     // Day     : |-----------------------------|
     // Options : |--1--|     |--2--|     |--3--|
 


### PR DESCRIPTION
-Add 5 tests for optional attendees:
Test that optional attendee is ignored or included when returning valid time ranges
Tests meet requirements as follows:

optionalAttendeeIsIgnoredInResult: Based on everyAttendeeIsConsidered, add an optional attendee C who has an all-day event. The same three time slots should be returned as when C was not invited.

optionalAttendeeIsConsidered: Also based on everyAttendeeIsConsidered, add an optional attendee C who has an event between 8:30 and 9:00. Now only the early and late parts of the day should be returned.

optionalAttendeeJustEnoughRoom: Based on justEnoughRoom, add an optional attendee B who has an event between 8:30 and 8:45. The optional attendee should be ignored since considering their schedule would result in a time slot smaller than the requested time.

optionalAttendeesWithGaps: No mandatory attendees, just two optional attendees with several gaps in their schedules. Those gaps should be identified and returned.

optionalAttendeesWithoutGaps: No mandatory attendees, just two optional attendees with no gaps in their schedules. query should return that no time is available.

- Add modification so that optional attendees are considered in the following way
    - if the event has only optional attendees, return the time ranges that work for optional attendees
    - if there are time ranges that work for both optional attendees and mandatory attendees return those
    - otherwise return the time ranges that work for all mandatory attendees
- Passes all 26 required tests
